### PR TITLE
Accomodate subclassing in rbind/cbind

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SingleCellExperiment
-Version: 1.1.2
-Date: 2017-01-06
+Version: 1.1.3
+Date: 2017-03-15
 Title: S4 Classes for Single Cell Data
 Authors@R: c(person("Aaron", "Lun", role=c("aut", "cph"),
         email="alun@wehi.edu.au"), person("Davide","Risso",

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -189,7 +189,7 @@ setMethod("cbind", "SingleCellExperiment", function(..., deparse.level=1) {
     new.rd <- SimpleList(do.call(mapply, c(all.rd, FUN=rbind, SIMPLIFY=FALSE)))
 
     ans <- args[[1]]
-    new("SingleCellExperiment", base, int_colData=new.col.data, int_elementMetadata=int_elementMetadata(ans),
+    new(class(ans), base, int_colData=new.col.data, int_elementMetadata=int_elementMetadata(ans),
         int_metadata=int_metadata(ans), reducedDims=new.rd)
 })
 
@@ -204,7 +204,7 @@ setMethod("rbind", "SingleCellExperiment", function(..., deparse.level=1) {
     new.row.data <- do.call(rbind, sout)
 
     ans <- args[[1]]
-    new("SingleCellExperiment", base, int_colData=int_colData(ans), int_elementMetadata=new.row.data,
+    new(class(ans), base, int_colData=int_colData(ans), int_elementMetadata=new.row.data,
         int_metadata=int_metadata(ans), reducedDims=reducedDims(ans))
 })
 


### PR DESCRIPTION
Rather than call `new('SingleCellExperiment', ...)` call `new(class(first_dot_arg), ...)`.

This does not test cleanly, but nor does the upstream HEAD. I verified that no additional test failures were added, but the current failures probably should be addressed before this is merged.

I believe there were some changes made about a week ago that did not get a version bump so that's why the Bioconductor builder doesn't report any problems with the current upstream HEAD  (version 1.1.2.)