### PR TITLE
Add ... to named assay getters/setters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: SingleCellExperiment
-Version: 1.3.5
+Version: 1.3.6
 Date: 2018-06-23
 Title: S4 Classes for Single Cell Data
 Authors@R: c(person("Aaron", "Lun", role=c("aut", "cph"),

--- a/R/SCE-getset.R
+++ b/R/SCE-getset.R
@@ -235,17 +235,17 @@ setMethod("objectVersion", "SingleCellExperiment", function(x) {
 #############################################
 # This defines some convenience wrappers for common entires in the assays slot.
 
-GET_FUN <- function(exprs_values) {
+GET_FUN <- function(exprs_values, ...) {
     (exprs_values) # To ensure evaluation
-    function(object) {
-        assay(object, i=exprs_values)
+    function(object, ...) {
+        assay(object, i=exprs_values, ...)
     }
 }
 
-SET_FUN <- function(exprs_values) {
+SET_FUN <- function(exprs_values, ...) {
     (exprs_values) # To ensure evaluation
-    function(object, value) {
-        assay(object, i=exprs_values) <- value
+    function(object, ..., value) {
+        assay(object, i=exprs_values, ...) <- value
         object
     }
 }

--- a/man/namedAssays.Rd
+++ b/man/namedAssays.Rd
@@ -28,29 +28,30 @@
 \description{Convenience methods to get or set named assay fields.}
 
 \usage{
-\S4method{counts}{SingleCellExperiment}(object)
-\S4method{counts}{SingleCellExperiment}(object) <- value
+\S4method{counts}{SingleCellExperiment}(object, ...)
+\S4method{counts}{SingleCellExperiment}(object, ...) <- value
 
-\S4method{normcounts}{SingleCellExperiment}(object)
-\S4method{normcounts}{SingleCellExperiment}(object) <- value
+\S4method{normcounts}{SingleCellExperiment}(object, ...)
+\S4method{normcounts}{SingleCellExperiment}(object, ...) <- value
 
-\S4method{logcounts}{SingleCellExperiment}(object)
-\S4method{logcounts}{SingleCellExperiment}(object) <- value
+\S4method{logcounts}{SingleCellExperiment}(object, ...)
+\S4method{logcounts}{SingleCellExperiment}(object, ...) <- value
 
-\S4method{cpm}{SingleCellExperiment}(object)
-\S4method{cpm}{SingleCellExperiment}(object) <- value
+\S4method{cpm}{SingleCellExperiment}(object, ...)
+\S4method{cpm}{SingleCellExperiment}(object, ...) <- value
 
-\S4method{tpm}{SingleCellExperiment}(object)
-\S4method{tpm}{SingleCellExperiment}(object) <- value
+\S4method{tpm}{SingleCellExperiment}(object, ...)
+\S4method{tpm}{SingleCellExperiment}(object, ...) <- value
 }
 
 \arguments{
 \item{object}{A SingleCellExperiment object.}
 \item{value}{A numeric matrix of the same dimensions as \code{object}.}
+\item{...}{May contain \code{withDimnames}, which is forwarded to \code{\link[SummarizedExperiment]{assays}}}.
 }
 
 \details{
-These are wrapper methods for getting or setting \code{assay(object, i=X)} where \code{X} is the name of the method.
+These are wrapper methods for getting or setting \code{assay(object, i=X, ...)} where \code{X} is the name of the method.
 For example, \code{counts} will get or set \code{X="counts"}.
 This provide some convenience for users as well as encouraging standardization of naming across packages.
 

--- a/tests/testthat/test-sce-methods.R
+++ b/tests/testthat/test-sce-methods.R
@@ -218,3 +218,28 @@ test_that("assay getters/setters work", {
     expect_equivalent(logcounts(sce), v3)
     expect_error(counts(sce), "invalid subscript")
 })
+
+test_that("assay getters/setters respect withDimnames", {
+    sce_rownames <- paste0("G", seq_len(20000 / ncells))
+    sce_colnames <- paste0("S", seq_len(ncells))
+    v2 <- matrix(runif(20000), ncol=ncells)
+    counts(sce) <- v2
+    rownames(sce) <- sce_rownames
+    colnames(sce) <- sce_colnames
+    expect_identical(dimnames(counts(sce)), list(sce_rownames, sce_colnames))
+    expect_identical(dimnames(counts(sce, withDimnames=FALSE)), NULL)
+
+    v3 <- log2(v2)
+    logcounts(sce) <- v3
+    expect_identical(dimnames(logcounts(sce)), list(sce_rownames, sce_colnames))
+    expect_identical(dimnames(logcounts(sce, withDimnames=FALSE)), NULL)
+
+    cpm(sce) <- v3 + v2
+    expect_identical(dimnames(cpm(sce)), list(sce_rownames, sce_colnames))
+    expect_identical(dimnames(cpm(sce, withDimnames=FALSE)), NULL)
+
+    tpm(sce) <- v3 - v2
+    expect_equivalent(tpm(sce), v3-v2)
+    expect_identical(dimnames(tpm(sce)), list(sce_rownames, sce_colnames))
+    expect_identical(dimnames(tpm(sce, withDimnames=FALSE)), NULL)
+})


### PR DESCRIPTION
Allows passing of `withDimnames` argument to `assay()` and `assay()<-` (closes #19).