### PR TITLE
Improve `setReplaceMethod` for `sizeFactors`

### DIFF
--- a/R/SCE-sizeFactors.R
+++ b/R/SCE-sizeFactors.R
@@ -21,24 +21,31 @@ setMethod("sizeFactors", "SingleCellExperiment", function(object, type=NULL) {
 
 #' @export
 #' @importFrom BiocGenerics "sizeFactors<-"
-setReplaceMethod("sizeFactors", "SingleCellExperiment", function(object, type=NULL, ..., value) {
-    field <- .get_sf_field(type)
-    cd <- int_colData(object)
-    cd[[field]] <- value
-    int_colData(object) <- cd
+setReplaceMethod(
+    f = "sizeFactors",
+    signature = signature(
+        object = "SingleCellExperiment",
+        value = "numeric"
+    ),
+    function(object, type=NULL, ..., value) {
+        field <- .get_sf_field(type)
+        cd <- int_colData(object)
+        cd[[field]] <- value
+        int_colData(object) <- cd
 
-    if (!is.null(type)) {
-        .Deprecated(msg="'type=' is deprecated.")
-        md <- int_metadata(object)
-        if (is.null(value)) {
-            md$size_factor_names <- setdiff(md$size_factor_names, type)
-        } else {
-            md$size_factor_names <- union(md$size_factor_names, type)
+        if (!is.null(type)) {
+            .Deprecated(msg="'type=' is deprecated.")
+            md <- int_metadata(object)
+            if (is.null(value)) {
+                md$size_factor_names <- setdiff(md$size_factor_names, type)
+            } else {
+                md$size_factor_names <- union(md$size_factor_names, type)
+            }
+            int_metadata(object) <- md
         }
-        int_metadata(object) <- md
+        return(object)
     }
-    return(object)
-})
+)
 
 #' @export
 setMethod("clearSizeFactors", "SingleCellExperiment", function(object) {

--- a/R/SCE-sizeFactors.R
+++ b/R/SCE-sizeFactors.R
@@ -27,7 +27,7 @@ setReplaceMethod(
         object = "SingleCellExperiment",
         value = "numeric"
     ),
-    function(object, type=NULL, ..., value) {
+    signature = function(object, type=NULL, ..., value) {
         field <- .get_sf_field(type)
         cd <- int_colData(object)
         cd[[field]] <- value


### PR DESCRIPTION
Can we restrict the default `sizeFactors<-` assignment method to use `numeric` rather than `ANY`? This follows the conventions used in DESeq2.

Note that I didn't update the roxygen documentation and NAMESPACE in this pull request.