### PR TITLE
Pass `delayed` and `fill` to `combineCols()` of altExps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SingleCellExperiment
-Version: 1.21.0
-Date: 2022-08-29
+Version: 1.21.1
+Date: 2023-03-15
 Title: S4 Classes for Single Cell Data
 Authors@R: c(
         person("Aaron", "Lun", role=c("aut", "cph"), email="infinite.monkeys.with.keyboards@gmail.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: SingleCellExperiment
-Version: 1.20.0
+Version: 1.21.0
 Date: 2022-08-29
 Title: S4 Classes for Single Cell Data
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: SingleCellExperiment
-Version: 1.19.1
+Version: 1.20.0
 Date: 2022-08-29
 Title: S4 Classes for Single Cell Data
 Authors@R: c(

--- a/R/combine.R
+++ b/R/combine.R
@@ -308,7 +308,7 @@ setMethod("combineCols", "SingleCellExperiment", function(x, ..., delayed=TRUE, 
         }
 
         tryCatch({
-            new.altexps[[i]] <- SummarizedExperimentByColumn(do.call(combineCols, c(collated, list(use.names=use.names))))
+            new.altexps[[i]] <- SummarizedExperimentByColumn(do.call(combineCols, c(collated, list(use.names=use.names, delayed=delayed, fill=fill))))
         }, error=function(e) {
             warning("failed to combine '", i, "' in 'altExps(<", class(ans), ">)':\n  ", conditionMessage(e))
         })

--- a/tests/testthat/test-sce-combine.R
+++ b/tests/testthat/test-sce-combine.R
@@ -105,3 +105,35 @@ test_that("cbind handles errors in the internal fields correctly", {
     sce4 <- rbind(A=sce, B=sce) 
     expect_identical(objectVersion(sce4), objectVersion(sce))
 })
+
+test_that("combineCols passes on delay when combining altExps", {
+    sce.combined <- combineCols(sce, sce, use.names=FALSE, delayed=FALSE)
+    expect_is(assay(altExp(sce.combined)), "matrix")
+
+    sce.combined2 <- combineCols(sce, sce, use.names=FALSE, delayed=TRUE)
+    expect_is(assay(altExp(sce.combined2)), "DelayedMatrix")
+})
+
+test_that("combineCols passes on fill when combining altExps", {
+    sce1 <- sce[1:6, 1:10]
+    rownames(sce1) <- LETTERS[seq_len(nrow(sce1))]
+    colnames(sce1) <- letters[seq_len(ncol(sce1))]
+    altExp(sce1) <- altExp(sce1)[1:6, ]
+
+    sce2 <- sce[1:14, 11:20]
+    rownames(sce2) <- LETTERS[1:14]
+    colnames(sce2) <- letters[seq_len(ncol(sce2)) + ncol(sce1)]
+    altExp(sce2) <- altExp(sce2)[4:7, ]
+
+    sce.combined1 <- combineCols(sce1, sce2, use.names=TRUE)
+    expect_true(anyNA(assay(sce.combined1)))
+
+    sce.combined2 <- combineCols(sce1, sce2, use.names=TRUE, fill = -1)
+    expect_true(any(assay(sce.combined2) == -1))
+
+    sce.combined3 <- combineCols(sce1, sce2, use.names=TRUE)
+    expect_true(anyNA(assay(altExp(sce.combined3))))
+
+    sce.combined4 <- combineCols(sce1, sce2, use.names=TRUE, fill = -1)
+    expect_true(any(assay(sce.combined4) == -1))
+})


### PR DESCRIPTION
Following up from https://github.com/LTLA/mumosa/issues/5#issuecomment-1465296820.
`combineCols()` did not respect `delayed = FALSE` for the altExps.
In fixing this I saw that nor did it respect `fill`, so this PR fixes both.


## Before

```r
suppressPackageStartupMessages(library(scater))
sce <- mockSCE()
sce <- logNormCounts(sce)
sce <- runPCA(sce)

adt_sce <- mockSCE(ngenes=20)
adt_sce <- logNormCounts(adt_sce)
altExp(sce, "ADT") <- adt_sce

sce2 <- combineCols(sce, sce, delayed = FALSE, fill = 0)
class(logcounts(sce2))
#> [1] "matrix" "array"
class(logcounts(altExp(sce2, "ADT")))
#> [1] "DelayedMatrix"
#> attr(,"package")
#> [1] "DelayedArray"
```

## After

``` r
suppressPackageStartupMessages(library(scater))
sce <- mockSCE()
sce <- logNormCounts(sce)
sce <- runPCA(sce)

adt_sce <- mockSCE(ngenes=20)
adt_sce <- logNormCounts(adt_sce)
altExp(sce, "ADT") <- adt_sce

sce2 <- combineCols(sce, sce, delayed = FALSE, fill = 0)
class(logcounts(sce2))
#> [1] "matrix" "array"
class(logcounts(altExp(sce2, "ADT")))
#> [1] "matrix" "array"
```