### PR TITLE
Prevent swapAltExp from downgrading TreeSE to SCE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SingleCellExperiment
-Version: 1.35.1
-Date: 2026-05-14
+Version: 1.35.2
+Date: 2026-07-16
 Title: S4 Classes for Single Cell Data
 Authors@R: c(
         person("Aaron", "Lun", role=c("aut", "cph"), email="infinite.monkeys.with.keyboards@gmail.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,4 @@ License: GPL-2 | GPL-3
 URL: https://github.com/drisso/SingleCellExperiment
 BugReports: https://github.com/drisso/SingleCellExperiment/issues
 VignetteBuilder: knitr
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R/swapAltExp.R
+++ b/R/swapAltExp.R
@@ -8,7 +8,8 @@
 #' If \code{NULL}, the original is not saved.
 #' @param withColData Logical scalar specifying whether the column metadata of \code{x} should be preserved in the output.
 #'
-#' @return A SingleCellExperiment derived from \code{altExp(x, name)}.
+#' @return An object derived from \code{altExp(x, name)} and upgraded to
+#' \linkS4class{SingleCellExperiment} if not already a subclass thereof.
 #' This contains all alternative Experiments in \code{altExps(x)}, excluding the one that was promoted to the main Experiment.
 #' An additional alternative Experiment containing \code{x} may be included if \code{saved} is specified.
 #' 
@@ -54,7 +55,10 @@
 #' @export
 swapAltExp <- function(x, name, saved=mainExpName(x), withColData=TRUE) {
     y <- altExp(x, name, withColData=withColData)
-    y <- as(y, "SingleCellExperiment")
+    
+    if (!inherits(y, "SingleCellExperiment")) {
+        y <- as(y, "SingleCellExperiment")
+    }
 
     all.ae <- altExps(x, withColData=FALSE)
     altExps(y) <- all.ae[setdiff(names(all.ae), name)]

--- a/R/swapAltExp.R
+++ b/R/swapAltExp.R
@@ -8,8 +8,7 @@
 #' If \code{NULL}, the original is not saved.
 #' @param withColData Logical scalar specifying whether the column metadata of \code{x} should be preserved in the output.
 #'
-#' @return An object derived from \code{altExp(x, name)} and upgraded to
-#' \linkS4class{SingleCellExperiment} if not already a subclass thereof.
+#' @return A \linkS4class{SingleCellExperiment} object created from \code{altExp(x, name)}.
 #' This contains all alternative Experiments in \code{altExps(x)}, excluding the one that was promoted to the main Experiment.
 #' An additional alternative Experiment containing \code{x} may be included if \code{saved} is specified.
 #' 
@@ -55,8 +54,7 @@
 #' @export
 swapAltExp <- function(x, name, saved=mainExpName(x), withColData=TRUE) {
     y <- altExp(x, name, withColData=withColData)
-    
-    if (!inherits(y, "SingleCellExperiment")) {
+    if (!is(y, "SingleCellExperiment")) {
         y <- as(y, "SingleCellExperiment")
     }
 

--- a/man/swapAltExp.Rd
+++ b/man/swapAltExp.Rd
@@ -17,7 +17,8 @@ If \code{NULL}, the original is not saved.}
 \item{withColData}{Logical scalar specifying whether the column metadata of \code{x} should be preserved in the output.}
 }
 \value{
-A SingleCellExperiment derived from \code{altExp(x, name)}.
+An object derived from \code{altExp(x, name)} and upgraded to
+\linkS4class{SingleCellExperiment} if not already a subclass thereof.
 This contains all alternative Experiments in \code{altExps(x)}, excluding the one that was promoted to the main Experiment.
 An additional alternative Experiment containing \code{x} may be included if \code{saved} is specified.
 }

--- a/man/swapAltExp.Rd
+++ b/man/swapAltExp.Rd
@@ -17,8 +17,7 @@ If \code{NULL}, the original is not saved.}
 \item{withColData}{Logical scalar specifying whether the column metadata of \code{x} should be preserved in the output.}
 }
 \value{
-An object derived from \code{altExp(x, name)} and upgraded to
-\linkS4class{SingleCellExperiment} if not already a subclass thereof.
+A \linkS4class{SingleCellExperiment} object created from \code{altExp(x, name)}.
 This contains all alternative Experiments in \code{altExps(x)}, excluding the one that was promoted to the main Experiment.
 An additional alternative Experiment containing \code{x} may be included if \code{saved} is specified.
 }


### PR DESCRIPTION
Hello!

I am a big fan of `swapAltExp`, but I noticed that it downgrades TreeSE etc. to SCE, which is not nice when you need to work with trees and other TreeSE-specific slots. With this patch, the original altExp is converted to SCE **only if** it does not already inherits SCE.

Working example after this patch:

```
library(SingleCellExperiment)
library(TreeSummarizedExperiment)

tse <- makeTSE()

altExp(tse, "alt") <- tse

tse <- swapAltExp(tse, "alt", saved = "main")

# Still a TreeSE object
class(tse)
# [1] "TreeSummarizedExperiment"
# attr(,"package")
# [1] "TreeSummarizedExperiment"
```

Happy to make adjustments if needed.

Cheers,
Giulio